### PR TITLE
Fix error `Abort trap: 6 error`

### DIFF
--- a/.github/workflows/build_macos_app.yml
+++ b/.github/workflows/build_macos_app.yml
@@ -31,18 +31,18 @@ jobs:
           cd dist/PDFMerger.app/Contents/MacOS/
           chmod +x PDFMerger
 
-    - name: Set up Homebrew
-       id: set-up-homebrew
-       uses: Homebrew/actions/setup-homebrew@master
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
-     - name: Install macOS packages
-       run: |
-         brew install create-dmg
+      - name: Install macOS packages
+        run: |
+          brew install create-dmg
 
-     - name: Convert app to dmg
-       run: |
-         chmod +x builddmg.sh
-         ./builddmg.sh
+      - name: Convert app to dmg
+        run: |
+          chmod +x builddmg.sh
+          ./builddmg.sh
 
       - name: Clean Up
         run: |


### PR DESCRIPTION
- Use dmg file to install the app will solve the `Abort trap: 6 error` issue
- Accroding to ChatGPT, the app can only be placed in the /Application folder, or it might trigger unkown issues